### PR TITLE
RSS, favicon, name changes

### DIFF
--- a/jobs/tasks.py
+++ b/jobs/tasks.py
@@ -5,6 +5,7 @@ from pythonjobs.services import Twitter
 @app.task
 def tweet(job_url):
     print("Sharing message on twitter")
-    message = u"Check the new job on http://pythonjobs.ie{0}".format(job_url)
+    message = u"There is a new job on http://pythonjobs.ie{0} " \
+        "#jobsearch #python #ireland".format(job_url)
     twitter = Twitter()
     twitter.tweet(message)

--- a/jobs/templates/base.html
+++ b/jobs/templates/base.html
@@ -5,7 +5,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Python Jobs</title>
+  <title>Python Jobs Ireland</title>
+  <link rel="shortcut icon" href="https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fc%2Fc3%2FPython-logo-notext.svg%2F1024px-Python-logo-notext.svg.png&f=1">
   {% load static %}
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 

--- a/jobs/templates/base.html
+++ b/jobs/templates/base.html
@@ -59,7 +59,8 @@
     <hr>
     <footer>
       <p class="pull-right social">
-        <a href="https://github.com/kimeraapp/pythonjobs.ie" target="_blank"><i class="fa fa-github fa-2x"></i></a>
+        <a href="http://feeds.feedburner.com/pythonjobs_ie" target="_blank"><i class="fa fa-rss fa-2x"></i></a>
+        <a class="social-middle" href="https://github.com/kimeraapp/pythonjobs.ie" target="_blank"><i class="fa fa-github fa-2x"></i></a>
         <a class="social-middle" href="https://facebook.com/pythonjobs.ie" target="_blank"><i class="fa fa-facebook fa-2x"></i></a>
         <a href="https://twitter.com/pythonjobs_ie" target="_blank"><i class="fa fa-twitter fa-2x"></i></a>
       </p>

--- a/jobs/templates/base.html
+++ b/jobs/templates/base.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Python Jobs Ireland</title>
-  <link rel="shortcut icon" href="https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fc%2Fc3%2FPython-logo-notext.svg%2F1024px-Python-logo-notext.svg.png&f=1">
+  <link rel="shortcut icon" href="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/110px-Python-logo-notext.svg.png">
   {% load static %}
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 

--- a/jobs/templates/edit.html
+++ b/jobs/templates/edit.html
@@ -5,7 +5,7 @@
       <div class="container">
         <div class="navbar-header">
           <a class="navbar-brand" href="/">
-            <img class="logo" src="https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fc%2Fc3%2FPython-logo-notext.svg%2F1024px-Python-logo-notext.svg.png&f=1" />
+            <img class="logo" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/110px-Python-logo-notext.svg.png" />
             <span class="logo blue">PythonJobs</span><span class="logo yellow">.ie</spa>
           </a>
         </div>

--- a/jobs/templates/index.html
+++ b/jobs/templates/index.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="jumbotron">
   <div class="container">
-    <h1>This is Python Jobs</h1>
+    <h1>This is Python Jobs Ireland</h1>
     <p>Find or post Python related jobs available in Ireland for free and without having to register.</p>
       <a class="btn btn-primary btn-lg" href="{% url 'job-new' %}" role="button">Post a Job</a>
   </div>

--- a/jobs/templates/new.html
+++ b/jobs/templates/new.html
@@ -5,7 +5,7 @@
       <div class="container">
         <div class="navbar-header">
           <a class="navbar-brand" href="/">
-            <img class="logo" src="https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fc%2Fc3%2FPython-logo-notext.svg%2F1024px-Python-logo-notext.svg.png&f=1" />
+            <img class="logo" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/110px-Python-logo-notext.svg.png" />
             <span class="logo blue">PythonJobs</span><span class="logo yellow">.ie</spa>
           </a>
         </div>

--- a/jobs/templates/show.html
+++ b/jobs/templates/show.html
@@ -5,7 +5,7 @@
     <div class="container">
       <div class="navbar-header">
         <a class="navbar-brand" href="/">
-          <img class="logo" src="https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2Fc%2Fc3%2FPython-logo-notext.svg%2F1024px-Python-logo-notext.svg.png&f=1" />
+          <img class="logo" src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/110px-Python-logo-notext.svg.png" />
           <span class="logo blue">PythonJobs</span><span class="logo yellow">.ie</spa>
         </a>
       </div>

--- a/jobs/templates/show.html
+++ b/jobs/templates/show.html
@@ -46,13 +46,19 @@
       <div class="clearfix"></div>
 
       <h3 class="bold border title">Apply</h3>
-      <p>
+      {% if job.external_link %}
+        <p>
           <a class="btn btn-sm btn-primary" href="{{ job.external_link }}" target="_blank">
               External link
           </a>
-      </p>
+        </p>
+      {% endif %}
+
       <p>Send an email to <a class="color" href="mailto:{{ job.email }}">{{ job.email }}</a></p>
 
+      {% if job.phone %}
+        <span class="bold">Phone:</span> {{ job.phone }}<br />
+      {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Added RSS icon to footer Resolves #63 
Python Jobs becomes Python Jobs Ireland to keep consistency
Added favicon using url Resolves #67 
Changed Python logo urls from duckduckgo image to the original one
Added phone back if there is one and hide external link button if there is not one
Changed new job twitter message to include some hashtags