### PR TITLE
Expire job after two months

### DIFF
--- a/jobs/models.py
+++ b/jobs/models.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+from django.utils import timezone
 from django.db import models
 from django.db.models import signals
 from django.utils.html import strip_tags
@@ -50,6 +52,12 @@ class Job(models.Model):
 
     def get_absolute_url(self):
         return reverse('job-show', args=[str(self.id)])
+
+    @staticmethod
+    def get_actives(now=timezone.now()):
+        limit = now - timedelta(days=60)
+        return Job.objects.filter(
+            status=1, created_at__gt=limit).order_by("-created_at").all()
 
 
 def token_pre_save(signal, instance, sender, **kwargs):

--- a/jobs/tests/test_models.py
+++ b/jobs/tests/test_models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.utils import timezone
+from datetime import timedelta
 from unittest.mock import patch
 from model_mommy import mommy
 from jobs.models import Job
@@ -84,3 +85,13 @@ class TestJob(TestCase):
     def test_save_tweets_about_job(self):
         self.job.save()
         self.assertTrue(self.mock_tweet.called)
+
+    def test_get_active_jobs_return_jobs_status_one(self):
+        self.job.save()
+        jobs = Job.get_actives()
+        self.assertEqual(jobs[0].status, 1)
+
+    def test_get_active_jobs_return_jobs_created_at_less_than_two_months(self):
+        now = timezone.now() + timedelta(days=61)
+        self.job.save()
+        self.assertEqual(len(Job.get_actives(now)), 0)

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -8,7 +8,7 @@ class IndexView(generic.ListView):
     model = Job
     template_name = "index.html"
     context_object_name = "jobs"
-    queryset = Job.objects.filter(status=1).order_by("-created_at").all()
+    queryset = Job.get_actives()
 
 
 class ShowView(generic.DetailView):


### PR DESCRIPTION
Created method get_actives that returns jobs with status 1 and and created_at less than 60 days.
Fix #41